### PR TITLE
Add document ingestion and automatic rule mapping

### DIFF
--- a/mapper.py
+++ b/mapper.py
@@ -1,7 +1,6 @@
 # mapper.py
 import re
 from collections import defaultdict
-from .models import DocumentRuleMapping
 
 # Простейшая матрица ключевых слов → код статьи
 KEYWORD_MAP = {

--- a/models.py
+++ b/models.py
@@ -10,7 +10,8 @@ import uuid
 Base = declarative_base()
 
 def generate_uuid():
-    return str(uuid.uuid4())
+    """Generate UUID objects compatible with SQLAlchemy's UUID type."""
+    return uuid.uuid4()
 
 class Regulation(Base):
     __tablename__ = "regulations"

--- a/regulation_monitor.py
+++ b/regulation_monitor.py
@@ -1,9 +1,18 @@
 # regulation_monitor.py
+"""Monitor regulatory sources and update local rule records."""
+
 import requests
 from bs4 import BeautifulSoup
 from sqlalchemy.orm import Session
-from .models import Regulation, Rule
+from .models import (
+    Regulation,
+    Rule,
+    DocumentRuleMapping,
+    ComplianceAlert,
+    Document,
+)
 from datetime import datetime
+import re
 
 def fetch_regulation_text(url: str) -> str:
     """Получить текст нормативного документа (HTML→текст)."""
@@ -13,38 +22,55 @@ def fetch_regulation_text(url: str) -> str:
     return soup.get_text(separator="\n")
 
 def parse_rules(raw_text: str) -> list[dict]:
+    """Parse raw regulation text into individual rule entries.
+
+    The parser looks for blocks starting with ``Article <code>`` and captures the
+    optional title on the same line and the following content until the next
+    article header.
     """
-    Разбить текст закона на статьи/пункты и вернуть список словарей с
-    ключами: section_code, title, content.
-    Это место для доработки: пока разделяем по строкам 'Article'.
-    """
-    rules = []
-    for block in raw_text.split("\nArticle"):
+    rules: list[dict] = []
+    # Split text on lines that start with "Article <number>"
+    blocks = re.split(r"\n(?=Article\s+\d)", raw_text)
+    for block in blocks:
         block = block.strip()
         if not block:
             continue
-        # простейший парсер: отделяем код до первой точки
-        first_line, *rest = block.split("\n", 1)
-        section_code = first_line.split()[0]
-        title = " ".join(first_line.split()[1:]) if len(first_line.split()) > 1 else section_code
-        content = rest[0] if rest else ""
+        lines = block.splitlines()
+        first_line = lines[0]
+        m = re.match(r"Article\s+([\d\.\(\)a-zA-Z]+)\s*-?\s*(.*)", first_line)
+        if not m:
+            continue
+        code = m.group(1).strip()
+        title = m.group(2).strip()
+        content = "\n".join(lines[1:]).strip()
         rules.append({
-            "section_code": f"Article{section_code}",
+            "section_code": f"Article{code}",
             "title": title,
             "content": content,
         })
     return rules
 
-def update_regulation(db: Session, name: str, version: str, url: str) -> None:
+def update_regulation(db: Session, name: str, version: str, url: str) -> Regulation:
+    """Fetch the latest regulation text and update rules.
+
+    If this version already exists in the database the function exits early.
+    When a rule's content changes between versions, a ``ComplianceAlert`` is
+    generated for each document mapped to the previous version of that rule and
+    the document is marked as ``outdated``.
     """
-    Скачивает текущий текст регламента, сравнивает с сохранённым и обновляет
-    таблицы Regulation и Rule при изменениях.
-    """
+
     raw_text = fetch_regulation_text(url)
-    existing_reg = db.query(Regulation).filter_by(name=name, version=version).first()
-    if existing_reg:
-        # в этом MVP просто возвращаем, если такая версия уже есть
-        return
+    # Abort if the regulation version is already stored
+    if db.query(Regulation).filter_by(name=name, version=version).first():
+        return db.query(Regulation).filter_by(name=name, version=version).first()
+
+    previous_reg = (
+        db.query(Regulation)
+        .filter(Regulation.name == name)
+        .order_by(Regulation.version.desc())
+        .first()
+    )
+
     reg = Regulation(
         name=name,
         version=version,
@@ -54,9 +80,10 @@ def update_regulation(db: Session, name: str, version: str, url: str) -> None:
         status="active",
     )
     db.add(reg)
-    db.flush()  # чтобы получить id для связи
+    db.flush()  # obtain id for FK relations
+
     for rule_data in parse_rules(raw_text):
-        rule = Rule(
+        new_rule = Rule(
             regulation_id=reg.id,
             section_code=rule_data["section_code"],
             title=rule_data["title"],
@@ -66,5 +93,35 @@ def update_regulation(db: Session, name: str, version: str, url: str) -> None:
             effective_date=datetime.utcnow(),
             last_modified=datetime.utcnow(),
         )
-        db.add(rule)
+        db.add(new_rule)
+
+        if previous_reg:
+            old_rule = (
+                db.query(Rule)
+                .filter_by(regulation_id=previous_reg.id, section_code=rule_data["section_code"])
+                .first()
+            )
+            if old_rule and old_rule.content.strip() != rule_data["content"].strip():
+                old_len = len(old_rule.content or "")
+                new_len = len(rule_data["content"] or "")
+                severity = "major" if abs(new_len - old_len) / max(old_len, 1) > 0.1 else "minor"
+                mappings = db.query(DocumentRuleMapping).filter_by(rule_id=old_rule.id).all()
+                for mapping in mappings:
+                    priority = (
+                        "high" if severity == "major" or old_rule.risk_level in {"critical", "high"} else "medium"
+                    )
+                    alert = ComplianceAlert(
+                        document_id=mapping.document_id,
+                        rule_id=new_rule.id,
+                        alert_type="rule_updated",
+                        priority=priority,
+                        message=f"{rule_data['section_code']} updated",
+                    )
+                    db.add(alert)
+                    # mark document as outdated
+                    doc = db.query(Document).get(mapping.document_id)
+                    if doc:
+                        doc.compliance_status = "outdated"
+
     db.commit()
+    return reg

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,45 @@
+import tempfile
+from pathlib import Path
+import sys
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from annex4parser.document_ingestion import ingest_document
+from annex4parser.models import Base, Regulation, Rule, DocumentRuleMapping
+from annex4parser.mapper import KEYWORD_MAP
+
+import docx
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+def create_sample_docx(text: str) -> Path:
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.docx')
+    doc = docx.Document()
+    doc.add_paragraph(text)
+    doc.save(tmp.name)
+    return Path(tmp.name)
+
+def test_ingest_and_map_creates_mappings():
+    session = setup_db()
+    reg = Regulation(name='EU AI Act', version='1')
+    session.add(reg)
+    session.flush()
+    for code in KEYWORD_MAP.values():
+        session.add(Rule(regulation_id=reg.id, section_code=code, title='', content=''))
+    session.commit()
+
+    doc_path = create_sample_docx('This document covers risk management and documentation requirements.')
+
+    ingest_document(doc_path, session)
+
+    mappings = session.query(DocumentRuleMapping).all()
+    codes = {m.rule.section_code for m in mappings}
+    assert 'Article9.2' in codes
+    assert 'Article15.3' in codes

--- a/tests/test_regulation_monitor.py
+++ b/tests/test_regulation_monitor.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from annex4parser.models import Base, Document, DocumentRuleMapping, Regulation, Rule, ComplianceAlert
+from annex4parser.regulation_monitor import update_regulation
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+def test_update_regulation_creates_alerts(monkeypatch):
+    session = setup_db()
+
+    old_text = (
+        "Article 9.2 Risk management\nOld text.\n"
+        "Article 10.1 Data governance\nSame text.\n"
+    )
+    new_text = (
+        "Article 9.2 Risk management\nUpdated text.\n"
+        "Article 10.1 Data governance\nSame text.\n"
+    )
+
+    # first version
+    monkeypatch.setattr('annex4parser.regulation_monitor.fetch_regulation_text', lambda url: old_text)
+    update_regulation(session, 'EU AI Act', '1', 'http://example.com')
+
+    # create document mapped to Article9.2
+    rule_v1 = session.query(Rule).filter_by(section_code='Article9.2').first()
+    doc = Document(filename='doc.docx', file_path='doc.docx', ai_system_name='sys', document_type='risk_assessment')
+    session.add(doc)
+    session.flush()
+    session.add(DocumentRuleMapping(document_id=doc.id, rule_id=rule_v1.id))
+    session.commit()
+
+    # new version with updated article 9.2
+    monkeypatch.setattr('annex4parser.regulation_monitor.fetch_regulation_text', lambda url: new_text)
+    update_regulation(session, 'EU AI Act', '2', 'http://example.com')
+
+    alerts = session.query(ComplianceAlert).all()
+    assert len(alerts) == 1
+    alert = alerts[0]
+    assert alert.document_id == doc.id
+    new_rule = session.query(Rule).filter_by(section_code='Article9.2', version='2').first()
+    assert alert.rule_id == new_rule.id
+    # document should be marked outdated
+    assert session.get(Document, doc.id).compliance_status == 'outdated'


### PR DESCRIPTION
## Summary
- support PDF/DOCX ingestion and automatic rule mapping
- fix UUID generation for SQLAlchemy models
- add test for ingestion workflow
- monitor regulation versions and raise compliance alerts when rule text changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689293a1ef308329ba13ba2984292b32