### PR TITLE
fix workflow to run update-all via CLI

### DIFF
--- a/.github/workflows/regulation-update.yml
+++ b/.github/workflows/regulation-update.yml
@@ -17,12 +17,9 @@ jobs:
         with:
           python-version: '3.x'
       - run: pip install -r requirements.txt
+      - run: pip install -e .
       - name: Update regulations
-        run: |
-          python - <<'PY'
-          from RegulationMonitorV2 import RegulationMonitorV2
-          RegulationMonitorV2.update_all()
-          PY
+        run: python -m annex4parser update-all --db-url "$DATABASE_URL"
       - name: Sync rules into database
         run: |
           risk-detector sync_rules --db-url "$DATABASE_URL" --dir rules/risk


### PR DESCRIPTION
## Summary
- install package before running update-all
- call update-all using annex4parser CLI instead of inline import

## Testing
- `pytest -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_689893f46d388329a21a11e25b619309