### PR TITLE
fix workflow to run update-all via CLI

### DIFF
--- a/.github/workflows/regulation-update.yml
+++ b/.github/workflows/regulation-update.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       # Database connection string
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      PYTHONPATH: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -18,11 +19,7 @@ jobs:
           python-version: '3.x'
       - run: pip install -r requirements.txt
       - name: Update regulations
-        run: |
-          python - <<'PY'
-          from RegulationMonitorV2 import RegulationMonitorV2
-          RegulationMonitorV2.update_all()
-          PY
+        run: python -m annex4parser update-all --db-url "$DATABASE_URL"
       - name: Sync rules into database
         run: |
           risk-detector sync_rules --db-url "$DATABASE_URL" --dir rules/risk


### PR DESCRIPTION
## Summary
- run update-all without installing package in editable mode
- set PYTHONPATH so annex4parser is importable during workflow

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_689893f46d388329a21a11e25b619309