### PR TITLE
Fix source metadata handling and RSS duplicate alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ if result:
 from annex4parser.rss_listener import fetch_rss_feed, RSSMonitor
 
 # Получаем RSS-фид
-entries = await fetch_rss_feed("https://eur-lex.europa.eu/legal-content/EN/RSS/?type=latestLegislation")
+entries = await fetch_rss_feed("https://www.europarl.europa.eu/rss/doc/debates-plenary/en.xml")
 
 # Мониторим изменения
 monitor = RSSMonitor()
@@ -454,10 +454,10 @@ sources:
     freq: "6h"
     celex_id: "32024R1689"
     
-  - id: eurlex_latest_rss
-    url: "https://eur-lex.europa.eu/legal-content/EN/RSS/?type=latestLegislation"
+  - id: ep_plenary
+    url: "https://www.europarl.europa.eu/rss/doc/debates-plenary/en.xml"
     type: rss
-    freq: "instant"
+    freq: "12h"
 ```
 
 ### Cache configuration

--- a/annex4parser/alerts/webhook.py
+++ b/annex4parser/alerts/webhook.py
@@ -291,7 +291,7 @@ if __name__ == "__main__":
         )
         
         emitter.emit_rss_update(
-            source_id="eurlex_latest_rss",
+            source_id="ep_plenary",
             title="New AI Regulation Published",
             link="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024R1234"
         )

--- a/annex4parser/rss_listener.py
+++ b/annex4parser/rss_listener.py
@@ -130,8 +130,7 @@ class RSSMonitor:
 
 # Примеры популярных регуляторных RSS-фидов
 REGULATORY_RSS_FEEDS = {
-    "eurlex_latest": "https://eur-lex.europa.eu/legal-content/EN/RSS/?type=latestLegislation",
-    "ep_plenary": "https://www.europarl.europa.eu/rss/en/plenary.xml",
+    "ep_plenary": "https://www.europarl.europa.eu/rss/doc/debates-plenary/en.xml",
     "ec_press": "https://ec.europa.eu/commission/presscorner/rss/en.xml",
     "eiopa": "https://www.eiopa.europa.eu/rss/en.xml",
 }
@@ -144,7 +143,7 @@ if __name__ == "__main__":
         monitor = RSSMonitor()
         
         # Проверяем EUR-Lex RSS
-        updates = await monitor.check_for_updates(REGULATORY_RSS_FEEDS["eurlex_latest"])
+        updates = await monitor.check_for_updates(REGULATORY_RSS_FEEDS["ep_plenary"])
         
         for link, content_hash, title in updates:
             print(f"New: {title}")

--- a/annex4parser/sources.yaml
+++ b/annex4parser/sources.yaml
@@ -20,12 +20,6 @@ sources:
     description: "EU AI Act original regulation"
     
   # --- RSS ---
-  - id: eurlex_latest_rss
-    type: rss
-    url: "https://eur-lex.europa.eu/legal-content/EN/RSS/?type=latestLegislation"
-    freq: "instant"
-    description: "EUR-Lex latest legislation RSS"
-    
   - id: ep_plenary
     type: rss
     url: "https://www.europarl.europa.eu/rss/doc/debates-plenary/en.xml"

--- a/examples/production_monitoring.py
+++ b/examples/production_monitoring.py
@@ -145,8 +145,8 @@ async def test_rss_monitoring():
     logger.info("Testing RSS monitoring...")
     
     try:
-        # Тестируем EUR-Lex RSS
-        entries = await fetch_rss_feed(REGULATORY_RSS_FEEDS["eurlex_latest"])
+        # Тестируем RSS пленарных заседаний Европарламента
+        entries = await fetch_rss_feed(REGULATORY_RSS_FEEDS["ep_plenary"])
         
         logger.info(f"Fetched {len(entries)} RSS entries")
         

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -43,7 +43,7 @@ class TestRegulationMonitorV2:
         source_ids = [s.id for s in sources]
         assert any("celex" in s_id for s_id in source_ids)  # celex_consolidated
         assert any("ai_act" in s_id for s_id in source_ids)  # ai_act_original
-        assert any("rss" in s_id for s_id in source_ids)  # eurlex_latest_rss
+        assert any(s.type == "rss" for s in sources)  # ep_plenary
 
     @pytest.mark.asyncio
     async def test_update_all_success(self, test_db, test_config_path):

--- a/tests/test_production_monitoring.py
+++ b/tests/test_production_monitoring.py
@@ -36,7 +36,7 @@ def sample_sources():
         },
         {
             "id": "test_rss",
-            "url": "https://eur-lex.europa.eu/legal-content/EN/RSS/?type=latestLegislation",
+            "url": "https://www.europarl.europa.eu/rss/doc/debates-plenary/en.xml",
             "type": "rss",
             "freq": "instant"
         }
@@ -300,7 +300,7 @@ class TestAlertEmitter:
         
         # Эмитируем RSS алерт
         emitter.emit_rss_update(
-            source_id="eurlex_latest_rss",
+            source_id="ep_plenary",
             title="New Regulation",
             link="https://example.com"
         )
@@ -308,7 +308,7 @@ class TestAlertEmitter:
         # Проверяем, что сообщение отправлено
         mock_producer.send.assert_called_once()
         call_args = mock_producer.send.call_args
-        assert call_args[1]["key"] == "eurlex_latest_rss"
+        assert call_args[1]["key"] == "ep_plenary"
 
 
 @pytest.mark.asyncio

--- a/tests/test_update_all_simple.py
+++ b/tests/test_update_all_simple.py
@@ -12,7 +12,7 @@ async def test_update_all_multisource(test_db, eli_rdf_v1, rss_xml_minor, test_c
     """Тест одновременной обработки ELI + RSS"""
     srcs = [
         Source(id="eli", url="https://eur-lex.europa.eu/eli-register?uri=eli%3a%2f%2flaw%2fregulation%2f2024%2f1689", type="eli_sparql", active=True, extra={"celex_id": "32024R1689"}),
-        Source(id="rss", url="https://eur-lex.europa.eu/legal-content/EN/RSS/?type=latestLegislation", type="rss", active=True)
+        Source(id="rss", url="https://www.europarl.europa.eu/rss/doc/debates-plenary/en.xml", type="rss", active=True)
     ]
     
     # Добавляем источники в БД


### PR DESCRIPTION
## Summary
- persist extra source fields like `celex_id` and SPARQL settings
- keep aiohttp session open while awaiting tasks
- improve RSS processing by recording item hashes and creating alerts only for new entries
- remove obsolete EUR-Lex RSS feed and replace with working European Parliament plenary feed across config, docs, and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c016ca5c83298e3e868ec9a667a9