### PR TITLE
refactor: reuse UA constant and broaden CELEX parsing

### DIFF
--- a/annex4parser/regulation_monitor_v2.py
+++ b/annex4parser/regulation_monitor_v2.py
@@ -372,7 +372,7 @@ class RegulationMonitorV2:
                 data={'query': query, 'format': 'application/sparql-results+json'},
                 headers={
                     'Accept': 'application/sparql-results+json',
-                    'User-Agent': 'Annex4ComplianceBot/1.0'
+                    'User-Agent': UA
                 },
                 timeout=aiohttp.ClientTimeout(total=30)
             ) as resp:
@@ -400,7 +400,7 @@ class RegulationMonitorV2:
                     params={'query': query, 'format': 'application/sparql-results+json'},
                     headers={
                         'Accept': 'application/sparql-results+json',
-                        'User-Agent': 'Annex4ComplianceBot/1.0'
+                        'User-Agent': UA
                     },
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
@@ -444,7 +444,7 @@ class RegulationMonitorV2:
         """Извлечь CELEX ID из URL."""
         import re
         logger.info(f"Extracting CELEX ID from URL: {url}")
-        match = re.search(r'CELEX%3A([A-Z0-9]+)', url, re.IGNORECASE)
+        match = re.search(r'(?:CELEX%3A|CELEX:)([A-Z0-9]+)', url, re.IGNORECASE)
         if match:
             celex_id = match.group(1)
             logger.info(f"Extracted CELEX ID: {celex_id}")

--- a/scripts/check_feeds.py
+++ b/scripts/check_feeds.py
@@ -2,6 +2,8 @@ import asyncio
 import aiohttp
 import feedparser
 
+from annex4parser.rss_listener import UA
+
 URLS = [
     "https://eur-lex.europa.eu/EN/display-feed.rss?rssId=162",
     "https://www.europarl.europa.eu/rss/doc/debates-plenary/en.xml",
@@ -9,13 +11,15 @@ URLS = [
 ]
 
 async def main():
-    async with aiohttp.ClientSession() as s:
+    async with aiohttp.ClientSession(headers={"User-Agent": UA}) as s:
         for u in URLS:
             async with s.get(u, timeout=30) as r:
                 r.raise_for_status()
                 raw = await r.text()
                 f = feedparser.parse(raw)
                 print(u, "→", len(f.entries), "items")
+                if getattr(f, "bozo", False):
+                    print("  Parsing error:", f.bozo_exception)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -170,6 +170,10 @@ class TestRegulationMonitorV2:
         # Тест с валидным URL (с CELEX параметром)
         celex_id = monitor._extract_celex_id("https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024R1689")
         assert celex_id == "32024R1689"
+
+        # Поддерживается и неэкранированный вариант
+        celex_id = monitor._extract_celex_id("https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689")
+        assert celex_id == "32024R1689"
         
         # Тест с невалидным URL
         celex_id = monitor._extract_celex_id("https://example.com/invalid")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
-from annex4parser.regulation_monitor_v2 import RegulationMonitorV2
 import re
 
 
 def test_extract_celex_id_handles_letters():
-    m = re.search(r'CELEX%3A([A-Z0-9]+)', '...CELEX%3A52021PC0206', re.IGNORECASE)
-    assert m.group(1) == '52021PC0206'
+    pattern = re.compile(r'(?:CELEX%3A|CELEX:)([A-Z0-9]+)', re.IGNORECASE)
+    assert pattern.search('...CELEX%3A52021PC0206').group(1) == '52021PC0206'
+    assert pattern.search('...CELEX:52021PC0206').group(1) == '52021PC0206'


### PR DESCRIPTION
## Summary
- reuse UA constant for SPARQL requests
- allow extracting CELEX IDs from both encoded and plain URLs
- add UA header and parsing error output to feed checker script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68991f791e1c83298c98e022e8e163ad