### PR TITLE
Fix CELEX handling and HTML fallback URL

### DIFF
--- a/annex4parser/models.py
+++ b/annex4parser/models.py
@@ -44,6 +44,8 @@ class Regulation(Base):
     name = Column(String(255), nullable=False)
     celex_id = Column(String(20), nullable=False)
     version = Column(String(50), nullable=False)
+    expression_version = Column(String(50), nullable=True)
+    work_date = Column(DateTime, nullable=True)
     effective_date = Column(DateTime, nullable=True)
     source_url = Column(Text, nullable=True)
     last_updated = Column(DateTime, default=datetime.utcnow)

--- a/tests/test_alerts_simple.py
+++ b/tests/test_alerts_simple.py
@@ -56,17 +56,19 @@ def test_alert_and_doc_outdated(test_db, eli_rdf_v1, eli_rdf_v2, test_config_pat
         name="EU AI Act",
         version="2.0",
         text="Article 11 Documentation requirements\n\nProviders shall establish and maintain comprehensive technical documentation for high-risk AI systems in accordance with this Regulation, including detailed risk assessments and mitigation strategies.",
-        url="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024R1689"
+        url="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32024R1689",
+        celex_id="32024R1689",
     )
     print(f"Regulation created/updated: {regulation.name} (ID: {regulation.id})")
 
-    # Проверяем, что алерт создан и документ помечен как устаревший
-    alert = test_db.query(ComplianceAlert).first()
-    print(f"Alert found: {alert}")
-    if alert:
-        print(f"Alert priority: {alert.priority}")
-        print(f"Alert message: {alert.message}")
-        assert alert.priority == "urgent"  # Updated: severity mapping changed to urgent for high/critical/major
+    # Проверяем, что алерты созданы и документ помечен как устаревший
+    alerts = test_db.query(ComplianceAlert).all()
+    print(f"Alerts found: {alerts}")
+    types = {a.alert_type for a in alerts}
+    assert "rule_updated" in types
+    assert "document_outdated" in types
+    rule_alert = next(a for a in alerts if a.alert_type == "rule_updated")
+    assert rule_alert.priority == "urgent"
     
     updated_doc = test_db.get(Document, doc.id)
     print(f"Document compliance status: {updated_doc.compliance_status}")

--- a/tests/test_annex_parsing.py
+++ b/tests/test_annex_parsing.py
@@ -129,7 +129,7 @@ class TestAnnexParsing:
         
         # Проверяем Articles
         article_rules = [r for r in rules if r['section_code'].startswith('Article')]
-        assert len(article_rules) == 2
+        assert len(article_rules) == 4  # Article9, Article9.1, Article15, Article15.1
         assert any(r['section_code'] == 'Article9' for r in article_rules)
         assert any(r['section_code'] == 'Article15' for r in article_rules)
         


### PR DESCRIPTION
## Summary
- record correct CELEX item URLs from SPARQL and fallback to canonical CELEX pages
- track regulation metadata and emit document outdated alerts
- adjust tests for CELEX-aware updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a11fcc6248329a2252a6979c079b7