### PR TITLE
Fix annex title parsing and dedup regulation versions

### DIFF
--- a/annex4parser/rss_listener.py
+++ b/annex4parser/rss_listener.py
@@ -138,6 +138,8 @@ class RSSMonitor:
 # Примеры популярных регуляторных RSS-фидов
 REGULATORY_RSS_FEEDS = {
     "ep_plenary": "https://www.europarl.europa.eu/rss/doc/debates-plenary/en.xml",
+    # Предопределённый фид EUR-Lex "All Parliament and Council legislation"
+    "eurlex_latest_legislation": "https://eur-lex.europa.eu/EN/display-feed.rss?rssId=162",
     "ec_press": "https://ec.europa.eu/commission/presscorner/rss/en.xml",
     "eiopa": "https://www.eiopa.europa.eu/rss/en.xml",
 }
@@ -148,9 +150,9 @@ if __name__ == "__main__":
     async def test_rss():
         # Тестируем RSS-монитор
         monitor = RSSMonitor()
-        
-        # Проверяем EUR-Lex RSS
-        updates = await monitor.check_for_updates(REGULATORY_RSS_FEEDS["ep_plenary"])
+
+        # Проверяем EUR-Lex RSS (предопределённый фид)
+        updates = await monitor.check_for_updates(REGULATORY_RSS_FEEDS["eurlex_latest_legislation"])
         
         for link, content_hash, title in updates:
             print(f"New: {title}")

--- a/scripts/check_feeds.py
+++ b/scripts/check_feeds.py
@@ -2,11 +2,11 @@ import asyncio
 import aiohttp
 import feedparser
 
-from annex4parser.rss_listener import UA
+from annex4parser.rss_listener import UA, REGULATORY_RSS_FEEDS
 
 URLS = [
-    "https://eur-lex.europa.eu/EN/display-feed.rss?rssId=162",
-    "https://www.europarl.europa.eu/rss/doc/debates-plenary/en.xml",
+    REGULATORY_RSS_FEEDS["eurlex_latest_legislation"],
+    REGULATORY_RSS_FEEDS["ep_plenary"],
     # "https://ec.europa.eu/newsroom/clima/items/itemType/1041?format=rss",
 ]
 

--- a/tests/test_annex_parsing.py
+++ b/tests/test_annex_parsing.py
@@ -24,6 +24,20 @@ class TestAnnexParsing:
         assert 'Technical documentation' in annex_rules[0]['title']
         assert 'parent_section_code' not in annex_rules[0]
 
+    def test_parse_annex_title_after_blank_line(self):
+        """Парсер должен извлекать заголовок, расположенный на новой строке."""
+        text = """
+        ANNEX IV
+
+        Technical documentation
+        1. First point
+        """
+
+        rules = parse_rules(text)
+        root = next(r for r in rules if r['section_code'] == 'AnnexIV')
+        assert root['title'] == 'Technical documentation'
+        assert 'First point' in root['content']
+
     def test_parse_annex_with_numbered_sections(self):
         """Тест парсинга Annex с пронумерованными подразделами."""
         text = """

--- a/tests/test_sanitize_content.py
+++ b/tests/test_sanitize_content.py
@@ -7,8 +7,13 @@ def test_sanitize_content_preserves_marker_with_text():
 
 
 def test_sanitize_content_drops_hanging_marker():
+    raw = "(a)\n\n"
+    assert _sanitize_content(raw) == ""
+
+
+def test_sanitize_content_preserves_marker_with_blank_line():
     raw = "(a)\n\nNext"
-    assert _sanitize_content(raw) == "Next"
+    assert _sanitize_content(raw).startswith("(a)")
 
 
 def test_parse_rules_with_separate_marker_line():


### PR DESCRIPTION
## Summary
- Capture Annex titles even when separated by blank lines
- Preserve list markers during sanitization and ensure HTML fallback reuses existing regulation versions
- Lookup metadata for HTML sources and avoid cloning regulations with identical text
- Synchronize rule versions and effective dates when reusing an existing regulation record
- Provide predefined EUR-Lex RSS feed and use it in feed checking script
- Normalize work_date strings from HTML sources before constructing version identifiers to ensure canonical YYYYMMDD formatting
- Forward normalized work_date from existing records when processing HTML sources to keep version comparison consistent
- Apply same-hash regulation reuse to legacy monitor path to prevent duplicate records when content is unchanged

## Testing
- `pytest tests/test_regulation_monitor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c2b8fdaf88329af2afb9f95090ffd