### PR TITLE
Refine version handling to rely on metadata only

### DIFF
--- a/annex4parser/models.py
+++ b/annex4parser/models.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     JSON,
     UniqueConstraint,
     Index,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import declarative_base, relationship
@@ -41,11 +42,18 @@ class Regulation(Base):
     __table_args__ = (
         UniqueConstraint("celex_id", "version", name="uq_regulation_celex_version"),
         Index("ix_regulations_celex_hash", "celex_id", "content_hash"),
+        Index(
+            "ux_regulations_celex_null_version",
+            "celex_id",
+            unique=True,
+            postgresql_where=text("version IS NULL"),
+            sqlite_where=text("version IS NULL"),
+        ),
     )
     id = Column(UUID(as_uuid=True), primary_key=True, default=generate_uuid)
     name = Column(Text, nullable=False)
     celex_id = Column(String(20), nullable=False)
-    version = Column(String(50), nullable=False)
+    version = Column(String(50), nullable=True)
     expression_version = Column(String(50), nullable=True)
     work_date = Column(DateTime, nullable=True)
     effective_date = Column(DateTime, nullable=True)

--- a/annex4parser/regulation_monitor.py
+++ b/annex4parser/regulation_monitor.py
@@ -422,7 +422,8 @@ class RegulationMonitor:
         )
         if same_hash_reg:
             updated = False
-            if same_hash_reg.version != version:
+            # Не затираем что-то осмысленное на None
+            if version is not None and same_hash_reg.version != version:
                 same_hash_reg.version = version
                 updated = True
             if same_hash_reg.effective_date is None:
@@ -431,7 +432,7 @@ class RegulationMonitor:
             if updated:
                 rules_q = self.db.query(Rule).filter_by(regulation_id=same_hash_reg.id)
                 for r in rules_q:
-                    if r.version != version:
+                    if version is not None and r.version != version:
                         r.version = version
                     if same_hash_reg.effective_date and r.effective_date is None:
                         r.effective_date = same_hash_reg.effective_date


### PR DESCRIPTION
## Summary
- stop falling back to the current date; version now derives only from expression_version or work_date metadata
- avoid overwriting stored versions with None and propagate only real versions to rules
- allow regulations without version metadata by making the column nullable
- guard legacy rule updates from resetting versions and add a partial index to avoid duplicate NULL-version entries

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c5651bea48329a64024ac2bd165ec