### PR TITLE
Fix misparsed year-like subsection numbers

### DIFF
--- a/annex4parser/regulation_monitor.py
+++ b/annex4parser/regulation_monitor.py
@@ -230,7 +230,8 @@ def parse_rules(raw_text: str) -> List[dict]:
 
 def _parse_article_subsections(rules: List[dict], parent_code: str, body: str):
     """Парсит пункты и подпункты внутри Article."""
-    top_parts = re.split(r"(?m)^\s*(\d+)\.\s+", body)
+    # Разрешаем только подпункты 1..999, исключаем года/большие числа
+    top_parts = re.split(r"(?m)^\s*([1-9]\d{0,2})\.\s+", body)
     if len(top_parts) >= 3:
         for i in range(1, len(top_parts), 2):
             num = top_parts[i]
@@ -267,7 +268,8 @@ def _parse_article_subsections(rules: List[dict], parent_code: str, body: str):
 def _parse_annex_subsections(rules: List[dict], parent_code: str, body: str):
     """Парсит подразделы внутри Annex."""
     # Разрежем по верхнему уровню "N." (в начале строки)
-    top_parts = re.split(r"(?m)^\s*(\d+)\.\s+", body)
+    # Разрешаем только подпункты 1..999, исключаем года/большие числа
+    top_parts = re.split(r"(?m)^\s*([1-9]\d{0,2})\.\s+", body)
     # split даёт: ["intro", "1", "text1", "2", "text2", ...]
     if len(top_parts) >= 3:
         for i in range(1, len(top_parts), 2):

--- a/tests/test_annex_parsing.py
+++ b/tests/test_annex_parsing.py
@@ -71,6 +71,21 @@ class TestAnnexParsing:
         assert section_1['parent_section_code'] == 'AnnexIV'
         assert section_2['parent_section_code'] == 'AnnexIV'
 
+    def test_annex_does_not_split_on_year_like_numbers(self):
+        """Парсер не должен считать строки с годом подпунктами."""
+        text = """
+        ANNEX IV Technical documentation
+
+        1. First point
+        2025. Given the rapid pace...
+        """
+
+        rules = parse_rules(text)
+
+        codes = {r['section_code'] for r in rules if r['section_code'].startswith('Annex')}
+        assert 'AnnexIV.1' in codes
+        assert 'AnnexIV.2025' not in codes
+
     def test_parse_annex_with_lettered_subsections(self):
         """Тест парсинга Annex с буквенными подпунктами."""
         text = """

--- a/tests/test_regulation_monitor.py
+++ b/tests/test_regulation_monitor.py
@@ -72,6 +72,18 @@ def test_order_index_zero_padding():
     assert r1a["order_index"] == "a"
     assert r1c["order_index"] == "c"
 
+
+def test_article_does_not_split_on_year_like_numbers():
+    text = (
+        "Article 39 Title\n"
+        "1. This is a normal point.\n"
+        "2025. Given the rapid pace...\n"
+    )
+    parsed = parse_rules(text)
+    codes = {r["section_code"] for r in parsed}
+    assert "Article39.1" in codes
+    assert "Article39.2025" not in codes
+
 def test_update_regulation_creates_alerts(monkeypatch):
     session = setup_db()
 


### PR DESCRIPTION
## Summary
- Prevent `_parse_article_subsections` and `_parse_annex_subsections` from splitting on numbers >=1000, avoiding year strings being treated as subsections
- Add regression tests to ensure year-like numbers don't create erroneous rules

## Testing
- `pytest tests/test_regulation_monitor.py::test_article_does_not_split_on_year_like_numbers tests/test_annex_parsing.py::TestAnnexParsing::test_annex_does_not_split_on_year_like_numbers -q`


------
https://chatgpt.com/codex/tasks/task_e_689c7c5d928483299e0a9e15beca4aa6