### PR TITLE
Improve annex title parsing and metadata retrieval

### DIFF
--- a/tests/test_annex_parsing.py
+++ b/tests/test_annex_parsing.py
@@ -38,6 +38,33 @@ class TestAnnexParsing:
         assert root['title'] == 'Technical documentation'
         assert 'First point' in root['content']
 
+    def test_parse_annex_title_bilingual_header(self):
+        """Парсер удаляет французский дубль и вторую языковую часть."""
+        text = """
+        ANNEX XI ANNEXE XI   Technical documentation referred to in Article 11(1)   Documentation technique
+
+        1. Content
+        """
+
+        rules = parse_rules(text)
+        root = next(r for r in rules if r['section_code'] == 'AnnexXI')
+        assert root['title'] == 'Technical documentation referred to in Article 11(1)'
+
+    def test_annex_title_excludes_subheadings(self):
+        """Подзаголовки после основной строки не попадают в title."""
+        text = """
+        ANNEX XI
+        Technical documentation referred to in Article 53(1), point (a) — technical documentation for providers of general-purpose AI models.
+        Transparency information referred to in Article 53(1), point (b) — technical documentation for providers of general-purpose AI models
+
+        1. Point one
+        """
+
+        rules = parse_rules(text)
+        root = next(r for r in rules if r['section_code'] == 'AnnexXI')
+        assert root['title'].startswith('Technical documentation referred to in Article 53(1)')
+        assert 'Transparency information referred to in Article 53(1)' in root['content']
+
     def test_parse_annex_with_numbered_sections(self):
         """Тест парсинга Annex с пронумерованными подразделами."""
         text = """

--- a/tests/test_sanitize_content.py
+++ b/tests/test_sanitize_content.py
@@ -21,3 +21,8 @@ def test_parse_rules_with_separate_marker_line():
     rules = parse_rules(text)
     sub = next(r for r in rules if r["section_code"] == "Article1.1.a")
     assert "Subpoint text" in sub["content"]
+
+
+def test_sanitize_content_removes_annexe_and_lang_markers():
+    raw = "ANNEXE IV\nEN\nFR\nSome text"
+    assert _sanitize_content(raw) == "Some text"


### PR DESCRIPTION
## Summary
- refine annex title extraction to capture first meaningful line and drop French duplicates
- clean language markers and "ANNEXE" remnants during sanitization
- pull regulation titles from ELI metadata when processing HTML sources
- add tests for bilingual headings and subheading exclusion
- avoid synthetic version when ELI metadata is missing in HTML fallback

## Testing
- `pytest tests/test_sanitize_content.py tests/test_annex_parsing.py tests/test_sparql_fallback_html.py -q`
- `pytest tests/test_monitor_core.py::TestRegulationMonitorV2::test_process_html_source_normalizes_work_date -q` *(fails: Connection refused: GET https://example.com/reg?uri=CELEX%253A32024R9999)*

------
https://chatgpt.com/codex/tasks/task_e_689c9a8f7e3c83299b6409bdc55f2337