### PR TITLE
Preserve full regulation titles

### DIFF
--- a/annex4parser/regulation_monitor.py
+++ b/annex4parser/regulation_monitor.py
@@ -191,8 +191,6 @@ def parse_rules(raw_text: str) -> List[dict]:
                         title_line_idx = k
                         break
                 rule_title = (title or None)
-                if rule_title:
-                    rule_title = rule_title[:120]
                 raw = "\n".join(lines[title_line_idx + 1:]).strip()
                 content = _sanitize_content(re.sub(r"\n{3,}", "\n\n", raw))
                 parent_code = canonicalize(f"Article{code}")
@@ -248,7 +246,7 @@ def parse_rules(raw_text: str) -> List[dict]:
                 parent_code = canonicalize(f"Annex{roman}")
                 rules.append({
                     "section_code": parent_code,
-                    "title": (annex_title[:120] or None),
+                    "title": (annex_title or None),
                     "content": body,
                 })
 


### PR DESCRIPTION
## Summary
- keep entire Article titles when parsing regulations
- keep entire Annex titles instead of truncating

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689cb657cf648329bf1b97b2870ced65