### PR TITLE
Improve Article header parsing and title cleanup

### DIFF
--- a/tests/test_annex_parsing.py
+++ b/tests/test_annex_parsing.py
@@ -174,7 +174,8 @@ class TestAnnexParsing:
 
         1. Providers shall maintain documentation.
 
-        ANNEX IV Technical documentation
+        ANNEX IV
+        Technical documentation
 
         1. General description:
            (a) intended purpose;


### PR DESCRIPTION
## Summary
- Relax Article boundary regex to permit inline titles while still skipping cross-references like `Article 98(2)`
- Normalize header tails by stripping duplicate `Artikel <num>` blocks and scanning up to 12 lines for a valid title
- Update tests to use inline Article titles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d928f63608329a631638848fd5c6c