### PR TITLE
Strip ELI footer lines during sanitization

### DIFF
--- a/annex4parser/regulation_monitor.py
+++ b/annex4parser/regulation_monitor.py
@@ -192,6 +192,9 @@ def _sanitize_content(text: str) -> str:
     cleaned = "\n".join(lines)
     cleaned = re.sub(r"[ \t]+", " ", cleaned)
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    # убираем служебные строки ELI футера EUR-Lex
+    cleaned = re.sub(r"(?im)^\s*ELI:\s*\S+.*$", "", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
     cleaned = _unwrap_soft_linebreaks(cleaned)
     return cleaned.strip()
 

--- a/annex4parser/regulation_monitor_v2.py
+++ b/annex4parser/regulation_monitor_v2.py
@@ -652,6 +652,9 @@ class RegulationMonitorV2:
         # схлопываем пробелы/пустые абзацы
         text = re.sub(r"[ \t]+", " ", text)
         text = re.sub(r"\n{3,}", "\n\n", text)
+        # drop ELI footer lines from OJ pages
+        text = re.sub(r"(?im)^\s*ELI:\s*\S+.*$", "", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
         text = _unwrap_soft_linebreaks(text)
         return text.strip()
 

--- a/tests/test_sanitize_content.py
+++ b/tests/test_sanitize_content.py
@@ -39,7 +39,18 @@ def test_sanitize_content_unwraps_hyphen_breaks():
     assert _sanitize_content(raw) == "interoperability"
 
 
+def test_sanitize_content_removes_eli_footer():
+    raw = "Some text\nELI: http://example.com/eli/123\nNext"
+    assert _sanitize_content(raw) == "Some text\n\nNext"
+
+
 def test_sanitize_text_unwraps_soft_linebreaks():
     monitor = RegulationMonitorV2.__new__(RegulationMonitorV2)
     raw = "including with other AI\nsystems, that are not"
     assert monitor._sanitize_text(raw) == "including with other AI systems, that are not"
+
+
+def test_sanitize_text_removes_eli_footer():
+    monitor = RegulationMonitorV2.__new__(RegulationMonitorV2)
+    raw = "Some text\nELI: http://example.com/eli/123\nNext"
+    assert monitor._sanitize_text(raw) == "Some text\n\nNext"


### PR DESCRIPTION
## Summary
- remove EUR-Lex ELI footer lines during rule text sanitation
- filter ELI footer lines in RegulationMonitorV2 text normalizer
- test ELI footer removal in both sanitizers

## Testing
- `pytest tests/test_sanitize_content.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a30381b2bc832999d419b0e0fbf6d0