### PR TITLE
Sanitize EUR-Lex tails in regulation monitors

### DIFF
--- a/annex4parser/regulation_monitor.py
+++ b/annex4parser/regulation_monitor.py
@@ -192,8 +192,18 @@ def _sanitize_content(text: str) -> str:
     cleaned = "\n".join(lines)
     cleaned = re.sub(r"[ \t]+", " ", cleaned)
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
-    # убираем служебные строки ELI футера EUR-Lex
-    cleaned = re.sub(r"(?im)^\s*ELI:\s*\S+.*$", "", cleaned)
+    # EUR-Lex footers/tails: ELI and OJ page markers
+    cleaned = re.sub(r"(?im)^\s*ELI:\s*\S+.*$", "", cleaned)  # whole-line ELI footer
+    cleaned = re.sub(
+        r"(?i)\s*\(?ELI:\s*[^\s)]+\)?([.,;:])?\n",
+        lambda m: (m.group(1) or "") + "\n\n",
+        cleaned,
+    )
+    cleaned = re.sub(r"(?i)\s*\(?ELI:\s*[^\s)]+\)?", "", cleaned)  # inline ELI reference
+    cleaned = re.sub(r"(?i)\s*https?://data\.europa\.eu/eli/\S+", "", cleaned)  # bare ELI URL
+    cleaned = re.sub(r"(?im)^\s*EN OJ L,?\s*\d{1,2}\.\d{1,2}\.\d{4}\s*$", "", cleaned)
+    cleaned = re.sub(r"(?im)^\s*\d{1,3}/\d{1,3}\s*$", "", cleaned)
+    cleaned = re.sub(r"[ \t]+", " ", cleaned)
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
     cleaned = _unwrap_soft_linebreaks(cleaned)
     return cleaned.strip()

--- a/annex4parser/regulation_monitor_v2.py
+++ b/annex4parser/regulation_monitor_v2.py
@@ -652,8 +652,18 @@ class RegulationMonitorV2:
         # схлопываем пробелы/пустые абзацы
         text = re.sub(r"[ \t]+", " ", text)
         text = re.sub(r"\n{3,}", "\n\n", text)
-        # drop ELI footer lines from OJ pages
-        text = re.sub(r"(?im)^\s*ELI:\s*\S+.*$", "", text)
+        # EUR-Lex footers/tails: ELI and OJ page markers
+        text = re.sub(r"(?im)^\s*ELI:\s*\S+.*$", "", text)  # whole-line ELI footer
+        text = re.sub(
+            r"(?i)\s*\(?ELI:\s*[^\s)]+\)?([.,;:])?\n",
+            lambda m: (m.group(1) or "") + "\n\n",
+            text,
+        )
+        text = re.sub(r"(?i)\s*\(?ELI:\s*[^\s)]+\)?", "", text)  # inline ELI reference
+        text = re.sub(r"(?i)\s*https?://data\.europa\.eu/eli/\S+", "", text)  # bare ELI URL
+        text = re.sub(r"(?im)^\s*EN OJ L,?\s*\d{1,2}\.\d{1,2}\.\d{4}\s*$", "", text)
+        text = re.sub(r"(?im)^\s*\d{1,3}/\d{1,3}\s*$", "", text)
+        text = re.sub(r"[ \t]+", " ", text)
         text = re.sub(r"\n{3,}", "\n\n", text)
         text = _unwrap_soft_linebreaks(text)
         return text.strip()

--- a/tests/test_sanitize_content.py
+++ b/tests/test_sanitize_content.py
@@ -54,3 +54,17 @@ def test_sanitize_text_removes_eli_footer():
     monitor = RegulationMonitorV2.__new__(RegulationMonitorV2)
     raw = "Some text\nELI: http://example.com/eli/123\nNext"
     assert monitor._sanitize_text(raw) == "Some text\n\nNext"
+
+
+def test_sanitizers_drop_inline_eli_and_bare_url():
+    raw = "Some text (ELI: http://data.europa.eu/eli/reg/2024/1689/oj).\nNext"
+    assert _sanitize_content(raw) == "Some text.\n\nNext"
+    mon = RegulationMonitorV2.__new__(RegulationMonitorV2)
+    assert mon._sanitize_text(raw) == "Some text.\n\nNext"
+
+
+def test_sanitizers_drop_oj_footer_and_page_counter():
+    raw = "Clause...\n45/144\nEN OJ L, 12.7.2024\n"
+    assert _sanitize_content(raw) == "Clause..."
+    mon = RegulationMonitorV2.__new__(RegulationMonitorV2)
+    assert mon._sanitize_text(raw) == "Clause..."


### PR DESCRIPTION
## Summary
- Strip EUR-Lex artifacts such as inline/bare ELI URLs, page counters and OJ footer lines in both monitors
- Cover ELI and OJ tail removal with new sanitizer tests

## Testing
- `pytest tests/test_sanitize_content.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a312025e14832993f262fcadaaee2a