### PR TITLE
Fix annex section and article title parsing

### DIFF
--- a/tests/test_annex_parsing.py
+++ b/tests/test_annex_parsing.py
@@ -188,10 +188,19 @@ class TestAnnexParsing:
         codes = {r['section_code'] for r in rules}
         assert 'Article49' not in codes
 
+        section_a = next(r for r in rules if r['section_code'] == 'AnnexVIII.A')
+        assert section_a['title'].startswith('Section A')
+        assert 'Section A' not in section_a['content']
         section_a1 = next(r for r in rules if r['section_code'] == 'AnnexVIII.A.1')
         assert 'name, address and contact details of the provider' in section_a1['content']
+        section_b = next(r for r in rules if r['section_code'] == 'AnnexVIII.B')
+        assert section_b['title'].startswith('Section B')
+        assert 'Section B' not in section_b['content']
         section_b1 = next(r for r in rules if r['section_code'] == 'AnnexVIII.B.1')
         assert 'name, address and contact details of the provider' in section_b1['content']
+        section_c = next(r for r in rules if r['section_code'] == 'AnnexVIII.C')
+        assert section_c['title'].startswith('Section C')
+        assert 'Section C' not in section_c['content']
         section_c1 = next(r for r in rules if r['section_code'] == 'AnnexVIII.C.1')
         assert 'name, address and contact details of the deployer' in section_c1['content']
 

--- a/tests/test_parse_annex_sections.py
+++ b/tests/test_parse_annex_sections.py
@@ -32,10 +32,20 @@ def test_parse_annex_viii_with_sections_abc():
     rules = parse_rules(raw)
     # Родитель
     assert any(r["section_code"] == "AnnexVIII" and r["content"] for r in rules)
-    # Секции
-    assert any(r["section_code"] == "AnnexVIII.A" and "Section A" in r["content"] for r in rules)
-    assert any(r["section_code"] == "AnnexVIII.B" for r in rules)
-    assert any(r["section_code"] == "AnnexVIII.C" for r in rules)
+    # Секции и их заголовки
+    sec_a = next(r for r in rules if r["section_code"] == "AnnexVIII.A")
+    assert sec_a["title"].startswith("Section A")
+    assert sec_a["content"].startswith("1. A item one")
+    assert "Section A" not in sec_a["content"]
+
+    sec_b = next(r for r in rules if r["section_code"] == "AnnexVIII.B")
+    assert sec_b["title"].startswith("Section B")
+    assert "Section B" not in sec_b["content"]
+
+    sec_c = next(r for r in rules if r["section_code"] == "AnnexVIII.C")
+    assert sec_c["title"].startswith("Section C")
+    assert "Section C" not in sec_c["content"]
+
     # Подпункты в секциях
     assert any(r["section_code"] == "AnnexVIII.A.1" and "A item one" in r["content"] for r in rules)
     assert any(r["section_code"] == "AnnexVIII.B.1" and "B item one" in r["content"] for r in rules)

--- a/tests/test_regulation_monitor.py
+++ b/tests/test_regulation_monitor.py
@@ -210,6 +210,20 @@ def test_annex_ii_title_detected():
     ann = next(r for r in parsed if r["section_code"] == "AnnexII")
     assert ann["title"] == "List of criminal offences referred to in Article 5(1), first subparagraph, point (h)(iii)"
 
+
+def test_article62_title_extracted():
+    text = (
+        "Article 62\n"
+        "Measures for providers and deployers, in particular SMEs, including start-ups\n"
+        "1. Providers and deployers shall do something.\n"
+    )
+    parsed = parse_rules(text)
+    art62 = next(r for r in parsed if r["section_code"] == "Article62")
+    assert art62["title"] == (
+        "Measures for providers and deployers, in particular SMEs, including start-ups"
+    )
+    assert not art62["content"].startswith("Measures for providers")
+
 def test_update_regulation_creates_alerts(monkeypatch):
     session = setup_db()
 


### PR DESCRIPTION
## Summary
- store Annex section headers in `title` instead of `content`
- improve article title detection to capture first title-like line before numbered points
- drop fallback that promoted first content line to article title
- add regression tests for Annex VIII sections and Article 62 heading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3978c07a48329a9eaceaf533adca2