### PR TITLE
Prefer HTML text for ELI SPARQL sources

### DIFF
--- a/annex4parser/sources.yaml
+++ b/annex4parser/sources.yaml
@@ -12,6 +12,7 @@ sources:
     freq: "6h"
     active: true   # включить, когда убедишься что запись доступна
     description: "EU AI Act consolidated version"
+    prefer_text: html
     
   - id: ai_act_original
     type: eli_sparql
@@ -21,6 +22,7 @@ sources:
     sparql: "file:queries/ai_act_original.rq"
     freq: "6h"
     description: "EU AI Act original regulation"
+    prefer_text: html
     
   # --- RSS ---
   - id: ep_plenary


### PR DESCRIPTION
## Summary
- default to HTML when fetching text for ELI SPARQL items and log chosen source
- allow sources to specify `prefer_text` and set default to `html` for AI Act sources

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a46a662d80832985d3377aeac9995e