### PR TITLE
Normalize list markers in text sanitizers

### DIFF
--- a/annex4parser/regulation_monitor_v2.py
+++ b/annex4parser/regulation_monitor_v2.py
@@ -658,6 +658,15 @@ class RegulationMonitorV2:
         # схлопываем пробелы/пустые абзацы
         text = re.sub(r"[ \t]+", " ", text)
         text = re.sub(r"\n{3,}", "\n\n", text)
+
+        # NEW: склеиваем «голые» маркеры перечислений с последующей строкой текста
+        # Примеры: "1.\nText" -> "1. Text", "(a)\nText" -> "(a) Text", "(i)\nText" -> "(i) Text"
+        label = r"(?:\(?\d+\)?\.?|\([a-z]\)|\([ivx]+\))"
+        text = re.sub(
+            rf"(?mi)^(?P<label>{label})\s*\n\s+(?!{label}\b)",
+            r"\g<label> ",
+            text,
+        )
         # EUR-Lex footers/tails: ELI and OJ page markers
         text = re.sub(r"(?im)^\s*ELI:\s*\S+.*$", "", text)  # whole-line ELI footer
         text = re.sub(


### PR DESCRIPTION
## Summary
- Merge standalone enumeration markers with following text lines in both `regulation_monitor._sanitize_content` and `regulation_monitor_v2._sanitize_text`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48a4a3ca08329bd71f8974bb2927e